### PR TITLE
Add 'stopwords' to nltk requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ python -m spacy download en_core_web_sm
 
 # nltk
 python -m nltk.downloader words
+python -m nltk.downloader stopwords
 ```
 
 # Documentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ python -m spacy download en_core_web_sm
 
 # nltk
 python -m nltk.downloader words
+python -m nltk.downloader stopwords
 ```
 
 ## Usage


### PR DESCRIPTION
I tried to run this from a clean install & got the error 

```
Resource stopwords not found.
  Please use the NLTK Downloader to obtain the resource:

  >>> import nltk
  >>> nltk.download('stopwords')
```
I then ran the command that I added to the README, and it worked fine.