### PR TITLE
Update setup.py to fix config.cfg error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'requests>=2.22.0',
         'six>=1.12.0',
         'sortedcontainers>=2.1.0',
-        'spacy>=2.1.4',
+        'spacy>=2.1.4,<=2.3.5',
         'srsly>=0.0.7',
         'thinc>=7.0.4',
         'tqdm>=4.32.2',


### PR DESCRIPTION
This change adds a maximum version to spacy and hence prevents the config.cfg error new users encounter.